### PR TITLE
fix(migration): avoid validity exclusion conflicts in fix paths

### DIFF
--- a/crates/tusker-migration/CHANGELOG.md
+++ b/crates/tusker-migration/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Avoid exclusion-constraint conflicts when fixing or deleting migrations by
+  splitting validity-range close and ledger insert into explicit transactional
+  statements with one shared database timestamp.
+
 ## [0.1.1] - 2026-05-23
 
 ### Changed

--- a/crates/tusker-migration/src/db.rs
+++ b/crates/tusker-migration/src/db.rs
@@ -67,15 +67,59 @@ impl Database {
         &self,
         migration_file: &MigrationFile,
     ) -> Result<(), PgError> {
-        let _ = query(
-            &self.client,
-            queries::MigrationUpdate {
-                number: migration_file.number,
-                name: &migration_file.name,
-                hash: &migration_file.hash,
-            },
-        )
-        .await?;
+        self.client.batch_execute("BEGIN").await?;
+        let result: Result<(), PgError> = async {
+            let timestamp: OffsetDateTime = self
+                .client
+                .query_one("SELECT clock_timestamp()", &[])
+                .await?
+                .get(0);
+
+            let _ = self
+                .client
+                .execute(
+                    "
+                    UPDATE migration
+                    SET validity = tstzrange(lower(validity), $2::timestamptz)
+                    WHERE migration.number = $1
+                      AND upper_inf(validity)
+                    ",
+                    &[&migration_file.number, &timestamp],
+                )
+                .await?;
+
+            let _ = self
+                .client
+                .execute(
+                    "
+                    INSERT INTO migration (number, name, hash, validity, operation)
+                    VALUES (
+                        $1,
+                        $2,
+                        $3,
+                        tstzrange($4::timestamptz, NULL::timestamptz),
+                        'update'
+                    )
+                    ",
+                    &[
+                        &migration_file.number,
+                        &migration_file.name,
+                        &migration_file.hash,
+                        &timestamp,
+                    ],
+                )
+                .await?;
+
+            Ok(())
+        }
+        .await;
+
+        if let Err(error) = result {
+            let _ = self.client.batch_execute("ROLLBACK").await;
+            return Err(error);
+        }
+
+        self.client.batch_execute("COMMIT").await?;
         Ok(())
     }
     pub(crate) async fn apply_migration(
@@ -112,7 +156,59 @@ impl Database {
         .map(|_| ())
     }
     pub(crate) async fn remove_migration(&self, number: i32) -> Result<(), PgError> {
-        let _ = query(&self.client, queries::MigrationDelete { number }).await?;
+        self.client.batch_execute("BEGIN").await?;
+        let result: Result<(), PgError> = async {
+            let timestamp: OffsetDateTime = self
+                .client
+                .query_one("SELECT clock_timestamp()", &[])
+                .await?
+                .get(0);
+
+            let closed = self
+                .client
+                .query_opt(
+                    "
+                    UPDATE migration
+                    SET validity = tstzrange(lower(validity), $2::timestamptz)
+                    WHERE migration.number = $1
+                      AND upper_inf(validity)
+                    RETURNING name, hash
+                    ",
+                    &[&number, &timestamp],
+                )
+                .await?;
+
+            if let Some(closed) = closed {
+                let name: String = closed.get(0);
+                let hash: Vec<u8> = closed.get(1);
+                let _ = self
+                    .client
+                    .execute(
+                        "
+                        INSERT INTO migration (number, name, hash, validity, operation)
+                        VALUES (
+                            $1,
+                            $2,
+                            $3,
+                            tstzrange($4::timestamptz, NULL::timestamptz),
+                            'delete'
+                        )
+                        ",
+                        &[&number, &name, &hash, &timestamp],
+                    )
+                    .await?;
+            }
+
+            Ok(())
+        }
+        .await;
+
+        if let Err(error) = result {
+            let _ = self.client.batch_execute("ROLLBACK").await;
+            return Err(error);
+        }
+
+        self.client.batch_execute("COMMIT").await?;
         Ok(())
     }
 }

--- a/crates/tusker-migration/src/queries.rs
+++ b/crates/tusker-migration/src/queries.rs
@@ -43,16 +43,3 @@ pub(crate) struct MigrationFake<'a> {
     pub(crate) hash: &'a [u8],
 }
 
-#[derive(Debug, Query)]
-#[query(sql = "migration_update", row = NoRow)]
-pub(crate) struct MigrationUpdate<'a> {
-    pub(crate) number: i32,
-    pub(crate) name: &'a str,
-    pub(crate) hash: &'a [u8],
-}
-
-#[derive(Copy, Clone, Debug, Query)]
-#[query(sql = "migration_delete", row = NoRow)]
-pub(crate) struct MigrationDelete {
-    pub(crate) number: i32,
-}


### PR DESCRIPTION
## Summary

Fix migration metadata repair paths to avoid exclusion-constraint conflicts on Postgres when closing and reopening validity ranges.

## Problem

Running `tusker migration fix <number>` for mismatch cases could fail with a DB error caused by a conflict on `(number, validity)` in the migration ledger table.

## Root Cause

The previous implementation used a combined update/insert style that could conflict with the exclusion constraint while transitioning an open-ended validity range.

## Changes

- Replace update/fix and delete/remove ledger writes with explicit transactional steps in `crates/tusker-migration/src/db.rs`
- Use one shared DB timestamp for validity close and new ledger insert
- Roll back transaction on error
- Remove now-unused query structs from `crates/tusker-migration/src/queries.rs`
- Document fix in `crates/tusker-migration/CHANGELOG.md`

## Validation

- `cargo check -p tusker-migration`
- `cargo test -p tusker-migration`
- Manual validation against JobMate migration ledger repair flow
